### PR TITLE
fix adaptor.js分包时重复执行

### DIFF
--- a/src/adaptor/src/alibaba.js
+++ b/src/adaptor/src/alibaba.js
@@ -22,6 +22,8 @@ function getInstance() {
   // eslint-disable-next-line no-undef
   const wx = my;
 
+  if (wx.has_ali_hook_flag) return
+
   wx.has_ali_hook_flag = true;
 
   // wx.hideNavigationBarLoading = my.hideNavigationBarLoading

--- a/src/adaptor/src/baidu.js
+++ b/src/adaptor/src/baidu.js
@@ -4,6 +4,8 @@ function getInstance() {
   // eslint-disable-next-line no-undef
   const wx = swan;
 
+  if (wx.has_baidu_hook_flag) return
+
   wx.has_baidu_hook_flag = true;
 
   const {

--- a/src/adaptor/src/toutiao.js
+++ b/src/adaptor/src/toutiao.js
@@ -18,6 +18,8 @@ function ignoreFn(opt) {
 function getInstance() {
   var wx = tt;
 
+  if (wx.has_toutiao_hook_flag) return
+
   wx.has_toutiao_hook_flag = true;
 
   wx.hideKeyboard = wx.hideKeyboard || emptyFn;


### PR DESCRIPTION
在转支付宝小程序时，分包加载打开对应的page页面时，adaptor.js重复执行，导致小程序应用下wx对象下的方法被多次重写

建议修复：
路径：src/adaptor/src/alibaba.js 修改如下：

原始代码：
function getInstance() {
// eslint-disable-next-line no-undef
const wx = my;
wx.has_ali_hook_flag = true;

........

return wx;
}

修改后代码：
function getInstance() {
// eslint-disable-next-line no-undef
const wx = my;
// fix 重复执行
if (wx.has_ali_hook_flag) {
return wx;
}
wx.has_ali_hook_flag = true;

........

return wx;
}